### PR TITLE
llamada de autocarga de trajectoria

### DIFF
--- a/js/MainHTMoL.js
+++ b/js/MainHTMoL.js
@@ -1249,6 +1249,7 @@ function RewFor(op) {
        
         tick();
         InitBufRepreDefault(commandsDefault);
+	main.loadTrjByScene();
     }
 
 


### PR DESCRIPTION
Se llama a la función carga la trajectoria al momento de cargar la página web (LINEA 1252)
main.loadTrjByScene();